### PR TITLE
Update to goreleaser for easier releasing of bins on Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,7 @@
+builds:
+  - binary: ssm-env
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - 386


### PR DESCRIPTION
I wanted to get the latest copy of this but noticed that the latest release wasn't up to date with master. One option is to use GoReleaser to make this easier. You can even use it on Circle to automatically release a new version on Github anytime there's a "v*.*.*" tag included -
 https://goreleaser.com/#continuous_integration

Anyways, just a suggestion, feel free to ignore.