### PR TITLE
Delay session creation until it really needed

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,7 @@ func TestExpandEnviron_NoSSMParameters(t *testing.T) {
 	e := expander{
 		t:  template.Must(parseTemplate(DefaultTemplate)),
 		os: os,
-		ssm: func() ssmClient {
+		ssmFunc: func() ssmClient {
 			return c
 		},
 		batchSize: defaultBatchSize,
@@ -42,7 +42,7 @@ func TestExpandEnviron_SimpleSSMParameter(t *testing.T) {
 	e := expander{
 		t:  template.Must(parseTemplate(DefaultTemplate)),
 		os: os,
-		ssm: func() ssmClient {
+		ssmFunc: func() ssmClient {
 			return c
 		},
 		batchSize: defaultBatchSize,
@@ -78,7 +78,7 @@ func TestExpandEnviron_CustomTemplate(t *testing.T) {
 	e := expander{
 		t:  template.Must(parseTemplate(`{{ if eq .Name "SUPER_SECRET" }}secret{{end}}`)),
 		os: os,
-		ssm: func() ssmClient {
+		ssmFunc: func() ssmClient {
 			return c
 		},
 		batchSize: defaultBatchSize,
@@ -114,7 +114,7 @@ func TestExpandEnviron_DuplicateSSMParameter(t *testing.T) {
 	e := expander{
 		t:  template.Must(parseTemplate(DefaultTemplate)),
 		os: os,
-		ssm: func() ssmClient {
+		ssmFunc: func() ssmClient {
 			return c
 		},
 		batchSize: defaultBatchSize,
@@ -152,7 +152,7 @@ func TestExpandEnviron_InvalidParameters(t *testing.T) {
 	e := expander{
 		t:  template.Must(parseTemplate(DefaultTemplate)),
 		os: os,
-		ssm: func() ssmClient {
+		ssmFunc: func() ssmClient {
 			return c
 		},
 		batchSize: defaultBatchSize,
@@ -180,7 +180,7 @@ func TestExpandEnviron_BatchParameters(t *testing.T) {
 	e := expander{
 		t:  template.Must(parseTemplate(DefaultTemplate)),
 		os: os,
-		ssm: func() ssmClient {
+		ssmFunc: func() ssmClient {
 			return c
 		},
 		batchSize: 1,

--- a/main_test.go
+++ b/main_test.go
@@ -16,9 +16,11 @@ func TestExpandEnviron_NoSSMParameters(t *testing.T) {
 	os := newFakeEnviron()
 	c := new(mockSSM)
 	e := expander{
-		t:         template.Must(parseTemplate(DefaultTemplate)),
-		os:        os,
-		ssm:       c,
+		t:  template.Must(parseTemplate(DefaultTemplate)),
+		os: os,
+		ssm: func() ssmClient {
+			return c
+		},
 		batchSize: defaultBatchSize,
 	}
 
@@ -38,9 +40,11 @@ func TestExpandEnviron_SimpleSSMParameter(t *testing.T) {
 	os := newFakeEnviron()
 	c := new(mockSSM)
 	e := expander{
-		t:         template.Must(parseTemplate(DefaultTemplate)),
-		os:        os,
-		ssm:       c,
+		t:  template.Must(parseTemplate(DefaultTemplate)),
+		os: os,
+		ssm: func() ssmClient {
+			return c
+		},
 		batchSize: defaultBatchSize,
 	}
 
@@ -72,9 +76,11 @@ func TestExpandEnviron_CustomTemplate(t *testing.T) {
 	os := newFakeEnviron()
 	c := new(mockSSM)
 	e := expander{
-		t:         template.Must(parseTemplate(`{{ if eq .Name "SUPER_SECRET" }}secret{{end}}`)),
-		os:        os,
-		ssm:       c,
+		t:  template.Must(parseTemplate(`{{ if eq .Name "SUPER_SECRET" }}secret{{end}}`)),
+		os: os,
+		ssm: func() ssmClient {
+			return c
+		},
 		batchSize: defaultBatchSize,
 	}
 
@@ -106,9 +112,11 @@ func TestExpandEnviron_DuplicateSSMParameter(t *testing.T) {
 	os := newFakeEnviron()
 	c := new(mockSSM)
 	e := expander{
-		t:         template.Must(parseTemplate(DefaultTemplate)),
-		os:        os,
-		ssm:       c,
+		t:  template.Must(parseTemplate(DefaultTemplate)),
+		os: os,
+		ssm: func() ssmClient {
+			return c
+		},
 		batchSize: defaultBatchSize,
 	}
 
@@ -142,9 +150,11 @@ func TestExpandEnviron_InvalidParameters(t *testing.T) {
 	os := newFakeEnviron()
 	c := new(mockSSM)
 	e := expander{
-		t:         template.Must(parseTemplate(DefaultTemplate)),
-		os:        os,
-		ssm:       c,
+		t:  template.Must(parseTemplate(DefaultTemplate)),
+		os: os,
+		ssm: func() ssmClient {
+			return c
+		},
 		batchSize: defaultBatchSize,
 	}
 
@@ -168,9 +178,11 @@ func TestExpandEnviron_BatchParameters(t *testing.T) {
 	os := newFakeEnviron()
 	c := new(mockSSM)
 	e := expander{
-		t:         template.Must(parseTemplate(DefaultTemplate)),
-		os:        os,
-		ssm:       c,
+		t:  template.Must(parseTemplate(DefaultTemplate)),
+		os: os,
+		ssm: func() ssmClient {
+			return c
+		},
 		batchSize: 1,
 	}
 


### PR DESCRIPTION
Right now even if no ssm parameters defined, deployment of the
service with ssm-env wrapper requires permissions like
(maybe not so permissive, but still)

```
{"Effect": "Allow", "Action": ["kms:*"], "Resource": "*"},
{"Effect": "Allow", "Action": ["ssm:*"], "Resource": Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*")}
 ```

 to start successfully as ssm client connects to keys storage and to
 parameters store