### PR TITLE
Add option to not exit if parameter lookup fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can most likely find the downloaded binary in `~/go/bin/ssm-env`
 ## Usage
 
 ```console
-ssm-env [-template STRING] [-with-decryption] COMMAND
+ssm-env [-template STRING] [-with-decryption] [-no-fail] COMMAND
 ```
 
 ## Details


### PR DESCRIPTION
Adds `-no-fail` parameter to ignore errors from SSM.

This is useful for me. I have multiple environments - some have SSM parameters, some don't (e.g. feature flags, other service endpoints). I'd rather the application can still continue if there is an error instead of the entire entrypoint failing.