### PR TITLE
Do not panic on EC2MetadataRequestError. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"os"
 	"os/exec"
 	"strings"
@@ -80,6 +81,10 @@ func awsSession() (*session.Session, error) {
 		meta := ec2metadata.New(sess)
 		identity, err := meta.GetInstanceIdentityDocument()
 		if err != nil {
+			awsErr := err.(awserr.Error)
+			if awsErr.Code() == "EC2MetadataRequestError" {
+				return sess, nil
+			}
 			return nil, err
 		}
 		return session.NewSession(&aws.Config{


### PR DESCRIPTION
Allow to run `ssm-env` tool outside the EC2 instance by using AWS Session with default configuration.

This is the improvement for the https://github.com/remind101/ssm-env/pull/14
The actual change was - check if we run on the EC2 instance and determine the EC2 region. But if we're not - it caused a panic. 

The change I propose - check the actual Code of the error and if the family of the code is `EC2MetadataRequestError` (we are actually not running on the EC2) - just return the default session (like it worked before the #14 fix)