### PR TITLE
Enforce static linking; bundle tzdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export CGO_ENABLED=0
 bin/ssm-env: *.go
 	# Enforce static linking, and copy the timezone data into the runtime so we
 	# can in places like scratch images.
-	go build -ldflags '-extldflags "-static"' -tags timetzdata -o $@ .
+	go build -ldflags '-extldflags "-static"' -o $@ .
 
 test:
 	# Testing for race conditions requires CGO be enabled.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .PHONY: test
 
+# Disable CGO by default.
+export CGO_ENABLED=0
+
 bin/ssm-env: *.go
-	CGO_ENABLED=0 go build -o $@ .
+	# Enforce static linking, and copy the timezone data into the runtime so we
+	# can in places like scratch images.
+	go build -ldflags '-extldflags "-static"' -tags timetzdata -o $@ .
 
 test:
-	go test -race $(shell go list ./... | grep -v /vendor/)
+	# Testing for race conditions requires CGO be enabled.
+	CGO_ENABLED=1 go test -race $(shell go list ./... | grep -v /vendor/)


### PR DESCRIPTION
We were producing a static binary because of building in alpine; this
change makes it more explicit, and also copies timezone data into the
binary, so it's available even when running somewhere like a scratch
container.