### PR TITLE
Add -V flag to print version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-.PHONY: test
+.DEFAULT_GOAL := bin/ssm-env
+
+ARGS :=
+
+version := $(shell git describe --tags --match 'v*')
+
+.PHONY: run
+run:
+	CGO_ENABLED=0 go run -ldflags "-X main.version=$(version)" . $(ARGS)
 
 bin/ssm-env: *.go
-	CGO_ENABLED=0 go build -o $@ .
+	CGO_ENABLED=0 go build -ldflags "-X main.version=$(version)" -o $@ .
 
+.PHONY: test
 test:
 	go test -race $(shell go list ./... | grep -v /vendor/)

--- a/main.go
+++ b/main.go
@@ -43,14 +43,23 @@ var TemplateFuncs = template.FuncMap{
 	"toUpper":    strings.ToUpper,
 }
 
+var version string
+
 func main() {
 	var (
-		template = flag.String("template", DefaultTemplate, "The template used to determine what the SSM parameter name is for an environment variable. When this template returns an empty string, the env variable is not an SSM parameter")
-		decrypt  = flag.Bool("with-decryption", false, "Will attempt to decrypt the parameter, and set the env var as plaintext")
-		nofail   = flag.Bool("no-fail", false, "Don't fail if error retrieving parameter")
+		template      = flag.String("template", DefaultTemplate, "The template used to determine what the SSM parameter name is for an environment variable. When this template returns an empty string, the env variable is not an SSM parameter")
+		decrypt       = flag.Bool("with-decryption", false, "Will attempt to decrypt the parameter, and set the env var as plaintext")
+		nofail        = flag.Bool("no-fail", false, "Don't fail if error retrieving parameter")
+		print_version = flag.Bool("V", false, "Print the version and exit")
 	)
 	flag.Parse()
 	args := flag.Args()
+
+	if *print_version {
+		fmt.Printf("%s\n", version)
+
+		return
+	}
 
 	if len(args) <= 0 {
 		flag.Usage()


### PR DESCRIPTION
It's hard to know which version of ssm-env you have post-install. This adds a -V flag to print the version.