### PR TITLE
Validate that SSM params have leading '/'

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,6 +187,11 @@ func (e *expander) expandEnviron(decrypt bool, nofail bool) error {
 		}
 
 		if parameter != nil {
+			// Ensure that this is a valid SSM parameter that we can actually resolve.
+			if !strings.HasPrefix(*parameter, "/") && !nofail {
+				return fmt.Errorf("SSM parameters must have a leading '/' (ssm:///<path>): %s", envvar)
+			}
+
 			uniqNames[*parameter] = true
 			ssmVars = append(ssmVars, ssmVar{k, *parameter})
 		}


### PR DESCRIPTION
A value like 'ssm://foo/bar' will currently get picked up as a parameter named 'foo/bar', but then the lookup in AWS will fail. These changes add a simple validation that the path has a leading '/'.